### PR TITLE
Migrate DataSources to use DataState

### DIFF
--- a/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/DataSource.kt
+++ b/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/DataSource.kt
@@ -6,7 +6,8 @@ interface DataSource<R : DataSourceRequest, T> {
     /**
      * Send a read request to the Datasource
      */
-    fun read(request: R): Publisher<DataSourceState<T>>
+    fun read(request: R): Publisher<DataState<T, Throwable>>
+
     /**
      * Save data to the datasource
      */

--- a/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/DataSourceState.kt
+++ b/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/DataSourceState.kt
@@ -1,5 +1,11 @@
 package com.mirego.trikot.datasources
 
+fun <T> DataState<T, out Throwable>.toDataSourceState() = when (this) {
+    is DataState.Data -> DataSourceState<T>(false, value)
+    is DataState.Error -> DataSourceState<T>(false, value, error)
+    is DataState.Pending -> DataSourceState<T>(true, value)
+}
+
 data class DataSourceState<T>(val isLoading: Boolean, val data: T?, val error: Throwable? = null) {
     fun <R> mapData(lambda: (T?) -> R?): DataSourceState<R> {
         return DataSourceState(isLoading, lambda(data), error)

--- a/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/DataSourceStateTests.kt
+++ b/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/DataSourceStateTests.kt
@@ -1,0 +1,20 @@
+package com.mirego.trikot.datasources
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DataSourceStateTests {
+    companion object {
+        const val YAY = "yay"
+        val NAY = Error("nay")
+    }
+
+    @Test
+    fun toDataSourceState() {
+        assertEquals(DataSourceState.dataLoaded(YAY), DataState.data<String, Error>(YAY).toDataSourceState())
+        assertEquals(DataSourceState.withError(NAY), DataState.error<String, Error>(NAY).toDataSourceState())
+        assertEquals(DataSourceState(false, YAY, NAY), DataState.error(NAY, YAY).toDataSourceState())
+        assertEquals(DataSourceState.loading(), DataState.pending<String, Error>().toDataSourceState())
+        assertEquals(DataSourceState(true, YAY, null), DataState.pending<String, Error>(YAY).toDataSourceState())
+    }
+}

--- a/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/testutils/asserts.kt
+++ b/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/testutils/asserts.kt
@@ -1,0 +1,13 @@
+package com.mirego.trikot.datasources.testutils
+
+import com.mirego.trikot.datasources.DataState
+import kotlin.test.assertTrue
+
+fun <V, E : Throwable> DataState<V, E>.assertValue(expectedValue: V) =
+    assertTrue { this is DataState.Data && value == expectedValue }
+
+fun <V, E : Throwable> DataState<V, E>.assertError(expectedError: E, expectedValue: V? = null) =
+    assertTrue { this is DataState.Error && error == expectedError && value == expectedValue }
+
+fun <V, E : Throwable> DataState<V, E>.assertPending(expectedValue: V? = null) =
+    assertTrue { this is DataState.Pending && value == expectedValue }


### PR DESCRIPTION
### Description
Migrate DataSources to use DataState instead of DataSourceState and provide adapter for backward compability

### Motivation
DataState sealed class is the new DataSource result class. 

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)