### PR TITLE
Add the possibility ton clean a BaseDataSource

### DIFF
--- a/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/DataSource.kt
+++ b/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/DataSource.kt
@@ -12,4 +12,9 @@ interface DataSource<R : DataSourceRequest, T> {
      * Save data to the datasource
      */
     fun save(request: R, data: T?)
+
+    /**
+     * Delete data in the datasource
+     */
+    fun delete(cachableId: Any)
 }

--- a/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/MemoryCacheDataSource.kt
+++ b/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/MemoryCacheDataSource.kt
@@ -30,4 +30,11 @@ class MemoryCacheDataSource<R : DataSourceRequest, T> : BaseDataSource<R, T>() {
             refreshPublisherWithId(request.cachableId)
         }
     }
+
+    override fun delete(cachableId: Any) {
+        val initialValue = memoryCache.value
+        val mutableMap = initialValue.toMutableMap()
+        mutableMap.remove(cachableId)
+        memoryCache.compareAndSet(initialValue, mutableMap)
+    }
 }


### PR DESCRIPTION
## Description
It's sometimes required to "clean" your datasource from all it's cache data or for only specific parts of data. This adds this possibility as well as the cleanup of the cachedDataSource associated to the BaseDataSource

## Motivation and Context
This requirement came up when I was trying to implement a real logout in my application. Even if I deleted the local data, the in memory datasources kept the old data in their publishers. Adding the possibility to clean everything up the way you want allows you to handle this the way your app needs. 
I'v also added a method to get the existing cachableIds of your datasource in case you would like to filter out any specific ids for a certain usecase.

## How Has This Been Tested?
I've tested this in my application as well with some unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Any of your existing DataSource will now have to implement `delete(cachableId: Any)` but if you don't use it you do not have to do anything in it.