### PR TITLE
Update to Kotlin 1.4 and bump version number to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@ buildscript {
         google()
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
     }
@@ -22,5 +23,6 @@ allprojects {
         google()
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,12 @@ buildscript {
         google()
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.5.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
+        classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.1.1'
     }
 }
 
@@ -23,6 +22,5 @@ allprojects {
         google()
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 }

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -8,7 +8,6 @@ plugins {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
@@ -19,6 +18,7 @@ android {
 repositories {
     google()
     jcenter()
+    mavenLocal()
     mavenCentral()
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
@@ -31,105 +31,87 @@ kotlin {
     android {
         publishAllLibraryVariants()
     }
-
-    targets {
-        fromPreset(presets.jvm, 'jvm')
-        fromPreset(presets.js, 'js')
-        fromPreset(presets.android, 'android')
-
-        fromPreset(presets.iosArm32, 'iosArm32')
-        fromPreset(presets.iosArm64, 'iosArm64')
-        fromPreset(presets.iosX64, 'iosX64')
-        fromPreset(presets.tvosArm64, 'tvosArm64')
-        fromPreset(presets.tvosX64, 'tvosX64')
+    jvm()
+    ios()
+    iosArm32('iosArm32')
+    tvos()
+    js {
+        browser()
+        nodejs()
     }
+
     sourceSets {
         commonMain {
             dependencies {
                 implementation "com.mirego.trikot:streams:$trikot_streams_version"
                 implementation "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
             }
         }
+
         commonTest {
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test-common'
                 implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
             }
         }
+
         jvmMain {
-            dependencies {
-                implementation "com.mirego.trikot:streams-jvm:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-jvm:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
+            dependsOn commonMain
         }
+
         jvmTest {
+            dependsOn commonTest
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test'
                 implementation 'org.jetbrains.kotlin:kotlin-test-junit'
             }
         }
+
         jsMain {
+            dependsOn commonMain
+        }
+
+        jsTest {
+            dependsOn commonTest
             dependencies {
-                implementation "com.mirego.trikot:streams-js:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-js:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
+                implementation 'org.jetbrains.kotlin:kotlin-test-js'
             }
         }
+
         androidMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
+            dependsOn commonMain
         }
+
         androidTest {
+            dependsOn commonTest
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test'
                 implementation 'org.jetbrains.kotlin:kotlin-test-junit'
             }
         }
+
         nativeMain {
-            dependsOn(commonMain)
+            dependsOn commonMain
         }
 
         iosArm32Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-iosarm32:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-iosarm32:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         iosArm64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-iosarm64:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-iosarm64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         iosX64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-iosx64:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-iosx64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         tvosArm64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-tvosarm64:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-tvosarm64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         tvosX64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-tvosx64:$trikot_streams_version"
-                implementation "com.mirego.trikot:trikotFoundation-tvosx64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
     }
 }
@@ -137,5 +119,5 @@ kotlin {
 release {
    checkTasks = ['check']
    buildTasks = ['publish']
-   updateVersionPart = 1
+   updateVersionPart = 2
 }

--- a/datasources/gradle.properties
+++ b/datasources/gradle.properties
@@ -1,2 +1,2 @@
 #Fri Jun 19 09:19:19 EDT 2020
-version=0.22.1-SNAPSHOT
+version=0.21.1-1.4-M3

--- a/datasources/gradle.properties
+++ b/datasources/gradle.properties
@@ -1,2 +1,2 @@
 #Fri Jun 19 09:19:19 EDT 2020
-version=0.21.1-1.4-M3
+version=1.0.0-SNAPSHOT

--- a/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/MemoryCacheDataSource.kt
+++ b/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/MemoryCacheDataSource.kt
@@ -1,7 +1,7 @@
 package com.mirego.trikot.datasources
 
-import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.executable.BaseExecutablePublisher
 import com.mirego.trikot.streams.reactive.executable.ExecutablePublisher
 

--- a/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseDataSourceTests.kt
+++ b/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseDataSourceTests.kt
@@ -6,9 +6,9 @@ import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue
 import com.mirego.trikot.streams.StreamsConfiguration
 import com.mirego.trikot.streams.cancellable.CancellableManager
-import com.mirego.trikot.streams.reactive.subscribe
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import com.mirego.trikot.streams.reactive.executable.ExecutablePublisher
+import com.mirego.trikot.streams.reactive.subscribe
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -57,7 +57,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher()
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchError(Throwable()) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val value = AtomicReference<DataState<String, Throwable>?>(null)
         networkDataSource.read(FakeRequest(simpleCachableId)).subscribe(cancellableManager!!) {
@@ -73,7 +74,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(networkResult) }
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val value = AtomicReference<DataState<String, Throwable>?>(null)
         networkDataSource.read(FakeRequest(simpleCachableId)).subscribe(cancellableManager!!) {
@@ -88,7 +90,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(networkResult) }
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val value = AtomicReference<DataState<String, Throwable>?>(null)
         val refreshedValue = AtomicReference<DataState<String, Throwable>?>(null)
@@ -96,9 +99,10 @@ class BaseDataSourceTests {
             value.compareAndSet(value.value, it)
         }
         val beforeRefreshValue = value.value
-        networkDataSource.read(FakeRequest(simpleCachableId, DataSourceRequest.Type.REFRESH_CACHE)).subscribe(cancellableManager!!) {
-            refreshedValue.compareAndSet(refreshedValue.value, it)
-        }
+        networkDataSource.read(FakeRequest(simpleCachableId, DataSourceRequest.Type.REFRESH_CACHE))
+            .subscribe(cancellableManager!!) {
+                refreshedValue.compareAndSet(refreshedValue.value, it)
+            }
 
         beforeRefreshValue!!.assertValue(cacheResult)
         value.value!!.assertValue(networkResult)
@@ -110,7 +114,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher()
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         networkDataSource.read(FakeRequest(simpleCachableId, DataSourceRequest.Type.REFRESH_CACHE))
 
@@ -130,7 +135,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchError(expectedError) }
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val value = AtomicReference<DataState<String, Throwable>?>(null)
         networkDataSource.read(FakeRequest(simpleCachableId)).subscribe(cancellableManager!!) {
@@ -147,7 +153,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher()
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val cacheId1 = "cacheId1"
         val cacheId2 = "cacheId2"
@@ -164,7 +171,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher()
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val cacheId1 = "cacheId1"
         val cacheId2 = "cacheId2"
@@ -183,7 +191,8 @@ class BaseDataSourceTests {
         val networkDataSourceReadPublisher = ReadFromCachePublisher()
         val cacheDataSourceReadPublisher = ReadFromCachePublisher().also { it.dispatchResult(cacheResult) }
         val cacheDataSource = BasicDataSource(mutableMapOf(simpleCachableId to cacheDataSourceReadPublisher))
-        val networkDataSource = BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
+        val networkDataSource =
+            BasicDataSource(mutableMapOf(simpleCachableId to networkDataSourceReadPublisher), cacheDataSource)
 
         val cacheId1 = "cacheId1"
         val cacheId2 = "cacheId2"
@@ -197,9 +206,15 @@ class BaseDataSourceTests {
         }
     }
 
-    data class FakeRequest(override val cachableId: Any, override val requestType: DataSourceRequest.Type = DataSourceRequest.Type.USE_CACHE) : DataSourceRequest
+    data class FakeRequest(
+        override val cachableId: Any,
+        override val requestType: DataSourceRequest.Type = DataSourceRequest.Type.USE_CACHE
+    ) : DataSourceRequest
 
-    class BasicDataSource(publishers: MutableMap<Any, ReadFromCachePublisher>, fallbackDataSource: DataSource<FakeRequest, String>? = null) : BaseDataSource<FakeRequest, String>(fallbackDataSource) {
+    class BasicDataSource(
+        publishers: MutableMap<Any, ReadFromCachePublisher>,
+        fallbackDataSource: DataSource<FakeRequest, String>? = null
+    ) : BaseDataSource<FakeRequest, String>(fallbackDataSource) {
         private val internalPublishers = AtomicReference(publishers)
 
         override fun internalRead(request: FakeRequest): ExecutablePublisher<String> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
-kotlin_version = 1.3.70
-trikot_foundation_version=0.30.1
-trikot_streams_version=0.63.1
+kotlin_version=1.4-M3
+trikot_foundation_version=0.30.1-1.4-M3
+trikot_streams_version=0.67.1-1.4-M3
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,9 @@
 kotlin.code.style=official
-kotlin_version=1.4-M3
-trikot_foundation_version=0.30.1-1.4-M3
-trikot_streams_version=0.67.1-1.4-M3
+kotlin_version=1.4.0
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false
+trikot_foundation_version=1.0.0
+trikot_streams_version=1.0.0
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,5 @@ pluginManagement {
     }
 }
 rootProject.name = 'trikot.datasources'
-enableFeaturePreview("GRADLE_METADATA")
 
 include ':datasources'


### PR DESCRIPTION
## Description
- Update Kotlin compiler to `1.4.0`
- Remove `GRADLE_METADATA` flag as module metadata is used in dependency resolution and included in publications by default in Gradle 6.0 and above
- Remove manual `stdlib` dependencies as they are now included by default
- Migrate to hierarchical project structure and use platform shortcuts.
- Bump version number to `1.0.0` and migrate to semantic versioning

## Motivation and Context
As Kotlin 1.4 has been officially released in the stable channel, it is time to update.

## How Has This Been Tested?
Tests in place still pass, to be tested integrated into an existing project.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Every project using trikot.datasources will need to update their own version of Kotlin to get the latest updates.