### PR TITLE
Fix iosx64 tests

### DIFF
--- a/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/testutils/asserts.kt
+++ b/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/testutils/asserts.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.datasources.testutils
 
 import com.mirego.trikot.datasources.DataState
+import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.subscribe
 import kotlin.test.assertNotNull
@@ -23,11 +24,11 @@ fun <T : Any> Publisher<T>.assertEquals(expectedValue: T?) {
 operator fun <T : Any> Publisher<T>.get(block: (T) -> Unit) = block(get())
 
 fun <T : Any> Publisher<T>.get(): T {
-    var value: T? = null
+    val atomicReference = AtomicReference<T?>(null)
     val cancellableManager = CancellableManager()
     subscribe(cancellableManager, onNext = {
-        value = it
+        atomicReference.compareAndSet(atomicReference.value, it)
     })
     cancellableManager.cancel()
-    return assertNotNull(value, "no value returned in get")
+    return assertNotNull(atomicReference.value, "no value returned in get")
 }


### PR DESCRIPTION
## Description
When testing for X64, we had a synchronousQueue that was redispatching on the next loop (and freezing in the same time). Changing the var value did make tests broken.

## Motivation and Context
Tests were failing, now they are not.

## How Has This Been Tested?
By making actual tests pass

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
