### PR TITLE
Update Kotlin to version 1.5.10 and add watchOS and macOS targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.0
+> 2021-06-08
+
+- Added watchOS and macOS targets
+- Updated Kotlin version to 1.5.10
+
 ## 2.1.0
 > 2021-05-10
 

--- a/datasources/build.gradle.kts
+++ b/datasources/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
     ios()
     iosArm32("iosArm32")
     tvos()
+    watchos()
+    macosX64()
     js(IR) {
         browser()
     }
@@ -99,6 +101,22 @@ kotlin {
         }
 
         val tvosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchos32Main by creating {
+            dependsOn(nativeMain)
+        }
+
+        val watchosArm64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val macosX64Main by getting {
             dependsOn(nativeMain)
         }
     }

--- a/datasources/gradle.properties
+++ b/datasources/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 10 16:27:06 EDT 2021
-version=2.1.1-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 kotlin.code.style=official
-kotlin_version=1.5.0
+kotlin_version=1.5.10
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-trikot_foundation_version=2.1.0
-trikot_streams_version=2.1.0
+trikot_foundation_version=2.2.1
+trikot_streams_version=2.2.0
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true


### PR DESCRIPTION
## 📖 Description
- Added watchOS and macOS targets
- Updated Kotlin version to 1.5.10

## 💭 Motivation and Context
macOS target was needed for a project

## 🧪 How Has This Been Tested?
`./gradlew build`

## 🦀 Dispatch
`#dispatch/kmp`